### PR TITLE
Log output in consistent location

### DIFF
--- a/book/logging.py
+++ b/book/logging.py
@@ -1,6 +1,6 @@
-import sys
+from pathlib import Path
 from logbook import Logger, RotatingFileHandler
 
 
-RotatingFileHandler('log').push_application()
+RotatingFileHandler(Path.home() / '.audio2book.log').push_application()
 log = Logger('Book')

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.md', 'r') as fh:
 
 setuptools.setup(
     name="audio2book",
-    version='0.1.3',
+    version='0.1.4',
     author="Robert Hughes",
     author_email='roberts.ginger.email@gmail.com',
     install_requires=['logbook'],


### PR DESCRIPTION
All logging output previously went to the current directory. It has now
been changed to go to $HOME/.audio2book.log